### PR TITLE
Add dedicated typecheck script and wire it into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,6 @@ jobs:
     - name: Run build
       run: |
         npm ci
+        npm run typecheck
         npm run build
         npm run lint

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "fix": "run-p fix:*",
     "fix:prettier": "prettier -w src/",
     "fix:eslint": "npm run lint:eslint -- --fix",
+    "typecheck": "tsc --noEmit",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
## Summary
- Add a standalone `typecheck` script (`tsc --noEmit`) so type errors are caught independently of the webpack build and lint steps.
- Wire `npm run typecheck` into CI, running before `npm run build`.

This is prep work for the planned TypeScript 7 (native compiler) migration: once the typecheck step exists and passes on the current TypeScript 6 toolchain, a follow-up PR will switch `tsc` to the native TS7 compiler via npm aliasing while keeping `ts-loader`/`typescript-eslint` on TS6-compatible APIs.

## Test plan
- [x] `npm run typecheck` passes locally
- [x] `npm run build` still succeeds
- [x] `npm run lint` still succeeds
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)